### PR TITLE
Updates to the Loading and Saving System

### DIFF
--- a/com.subtegral.dialoguesystem/Editor/Graph/StoryGraph.cs
+++ b/com.subtegral.dialoguesystem/Editor/Graph/StoryGraph.cs
@@ -13,7 +13,7 @@ namespace Subtegral.DialogueSystem.Editor
 {
     public class StoryGraph : EditorWindow
     {
-        private string _fileName = "New Narrative";
+        private string _fileName;
 
         private StoryGraphView _graphView;
         private DialogueContainer _dialogueContainer;
@@ -34,37 +34,33 @@ namespace Subtegral.DialogueSystem.Editor
             _graphView.StretchToParentSize();
             rootVisualElement.Add(_graphView);
         }
-
+        
+        private void RegenerateToolbar()
+        {
+            // remove the old toolbar
+            rootVisualElement.Remove(rootVisualElement.Q<Toolbar>());
+            // generate a new toolbar
+            GenerateToolbar();
+        }
+        
         private void GenerateToolbar()
         {
-            var toolbar = new Toolbar();
-
-            var fileNameTextField = new TextField("File Name:");
-            fileNameTextField.SetValueWithoutNotify(_fileName);
-            fileNameTextField.MarkDirtyRepaint();
-            fileNameTextField.RegisterValueChangedCallback(evt => _fileName = evt.newValue);
-            toolbar.Add(fileNameTextField);
-
-            toolbar.Add(new Button(() => RequestDataOperation(true)) {text = "Save Data"});
-
+            var toolbar           = new Toolbar();
+            toolbar.Add(new Button(() => RequestDataOperation(true)) {text  = "Save Data"});
             toolbar.Add(new Button(() => RequestDataOperation(false)) {text = "Load Data"});
-            // toolbar.Add(new Button(() => _graphView.CreateNewDialogueNode("Dialogue Node")) {text = "New Node",});
+            var fileNameTextField = new Label($"File Name: {_fileName}");
+            toolbar.Add(fileNameTextField);
             rootVisualElement.Add(toolbar);
         }
 
         private void RequestDataOperation(bool save)
         {
-            if (!string.IsNullOrEmpty(_fileName))
-            {
-                var saveUtility = GraphSaveUtility.GetInstance(_graphView);
-                if (save)
-                    saveUtility.SaveGraph(_fileName);
-                else
-                    saveUtility.LoadNarrative(_fileName);
-            }
-            else
-            {
-                EditorUtility.DisplayDialog("Invalid File name", "Please Enter a valid filename", "OK");
+            var saveUtility = GraphSaveUtility.GetInstance(_graphView);
+            if (save) {
+                saveUtility.SaveGraph();
+            } else {
+                saveUtility.LoadNarrative(out _fileName);
+                RegenerateToolbar();
             }
         }
 

--- a/com.subtegral.dialoguesystem/Editor/Graph/StoryGraph.cs
+++ b/com.subtegral.dialoguesystem/Editor/Graph/StoryGraph.cs
@@ -44,11 +44,13 @@ namespace Subtegral.DialogueSystem.Editor
         private void GenerateToolbar()
         {
             var toolbar           = new Toolbar();
-            toolbar.Add(new Button(() => RequestDataOperation(0)) {text  = "New Data"});
-            toolbar.Add(new Button(() => RequestDataOperation(1)) {text  = "Save Data"});
-            toolbar.Add(new Button(() => RequestDataOperation(2)) {text = "Load Data"});
-            var fileNameTextField = new Label($"File Name: {_fileName}");
-            toolbar.Add(fileNameTextField);
+            toolbar.Add(new Button(() => RequestDataOperation(0)) {text  = "New"});
+            toolbar.Add(new Button(() => RequestDataOperation(1)) {text  = "Save"});
+            toolbar.Add(new Button(() => RequestDataOperation(2)) {text = "Load"});
+            if (_fileName != string.Empty) {
+                var fileNameTextField = new Label($"File Name: {_fileName}");
+                toolbar.Add(fileNameTextField);
+            }
             rootVisualElement.Add(toolbar);
         }
 
@@ -71,10 +73,12 @@ namespace Subtegral.DialogueSystem.Editor
                 {
                     if (_filePath != string.Empty) {
                         saveUtility.SaveGraph(_filePath);
-                        Debug.Log($"Saved Narrative at: {_filePath}");
-                        break;
-                    }
-                    saveUtility.SaveGraph();
+                    } else saveUtility.SaveGraph(out _filePath);
+                    
+                    Debug.Log($"Saved Narrative at: {_filePath}");
+                    _fileName = _filePath.Split('/').Last();
+                    _fileName = _fileName[..^6];
+                    RegenerateToolbar();
                     break;
                 }
                 case 2:

--- a/com.subtegral.dialoguesystem/Editor/GraphSaveUtility.cs
+++ b/com.subtegral.dialoguesystem/Editor/GraphSaveUtility.cs
@@ -39,6 +39,7 @@ namespace Subtegral.DialogueSystem.Editor
                 return;
             
             SaveGraph(filePath);
+	    EditorUtility.RevealInFinder($"{filePath}");
         }
         
         public void SaveGraph(string filePath)
@@ -65,8 +66,6 @@ namespace Subtegral.DialogueSystem.Editor
             }
 
             AssetDatabase.SaveAssets();
-            // open file explorer to the folder where the file is saved
-            EditorUtility.RevealInFinder($"{filePath}");
         }
 
         private bool SaveNodes(DialogueContainer dialogueContainerObject)

--- a/com.subtegral.dialoguesystem/Editor/GraphSaveUtility.cs
+++ b/com.subtegral.dialoguesystem/Editor/GraphSaveUtility.cs
@@ -32,14 +32,16 @@ namespace Subtegral.DialogueSystem.Editor
             };
         }
 
-        public void SaveGraph()
+        public void SaveGraph() => SaveGraph(out _);
+
+        public void SaveGraph(out string filePath)
         {
-            var filePath = EditorUtility.SaveFilePanelInProject("Save Narrative", "New Narrative", "asset", "Pick a save location");
+            filePath = EditorUtility.SaveFilePanelInProject("Save Narrative", "New Narrative", "asset", "Pick a save location");
             if (string.IsNullOrEmpty(filePath))
                 return;
-            
+
             SaveGraph(filePath);
-	    EditorUtility.RevealInFinder($"{filePath}");
+            EditorUtility.RevealInFinder($"{filePath}");
         }
         
         public void SaveGraph(string filePath)


### PR DESCRIPTION
Instead of using the rudimentary and un-user friendly string loading/saving method, I've rewritten it to use the OS's built-in file browser to save and load assets.
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/47935791/234734669-709c067d-490a-4e8d-8865-0839fcd9b7c8.png">
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/47935791/234734732-e66f8279-2694-4d42-b628-7da1372da257.png">
